### PR TITLE
Added default activities to route

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -969,9 +969,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
@@ -993,7 +993,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -1008,6 +1008,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/finalhandler": {
@@ -1646,9 +1650,9 @@
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
     },
     "node_modules/proxy-addr": {

--- a/server/src/routes/opentripmapRoutes.ts
+++ b/server/src/routes/opentripmapRoutes.ts
@@ -1,6 +1,7 @@
 import express, { Request, Response, NextFunction } from 'express';
-import axios from 'axios'; // Assuming axios is already installed
-import { getActivitiesByCity, getActivityByXid  } from '../opentripmap';  // Correct import path
+import axios from 'axios'; 
+import { getActivitiesByCity, getActivityByXid } from '../opentripmap';  
+import { ActivityDetails  } from '../interfaces'; 
 
 const router = express.Router();
 
@@ -12,21 +13,83 @@ const asyncHandler = (fn: Function) => {
 };
 
 
+// old code
+// // Define the route to get activities by city
+// router.get('/', async (req: Request, res: Response) => {
+//   const location = req.query.location as string || 'New York';  // Default to 'New York' if no location is provided
 
-// Define the route to get activities by city
+//   try {
+//     const activities = await getActivitiesByCity(location);  // Fetch activities using predefined coordinates for the location
+//     const filteredActivities = activities.filter((activity: any) => activity && Object.keys(activity).length > 0);
+
+//     res.json(filteredActivities);
+//   } catch (error) {
+//     console.error('Error fetching activities:', error);
+//     res.status(500).send('Error fetching activities');
+//   }
+// });
+const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+const fetchWithRateLimit = async (xids: string[]) => {
+  const activities = [];
+  for (const xid of xids) {
+    try {
+      const activity = await getActivityByXid(xid);
+      activities.push(activity);
+      await delay(500); // Adjust delay time between calls
+    } catch (error) {
+      console.error(`Error fetching activity for XID ${xid}:`, error);
+      activities.push(null); // Push null to maintain array structure
+    }
+  }
+  return activities;
+};
+
+
+
+
+
 router.get('/', async (req: Request, res: Response) => {
-  const location = req.query.location as string || 'New York';  // Default to 'New York' if no location is provided
+  const location = req.query.location as string || 'New York'; // Default location
+  console.log('Requested location:', location);
 
   try {
-    const activities = await getActivitiesByCity(location);  // Fetch activities using predefined coordinates for the location
+    const defaultXids = ['W219292804', 'N681553665', 'W43888180', 'Q5639048', 'Q12410485', 'N2645430237', 'W44285817', 'N1731465814', 'Q2918780', 'Q632602', 'Q12016578', 'N1669839900'];
+    console.log('Default XIDs:', defaultXids);
+
+    // Fetch default activities
+    const defaultActivities = await fetchWithRateLimit(defaultXids);
+
+    console.log('Fetched default activities:', defaultActivities);
+
+    // Remove null/undefined entries with proper type guard
+    const validDefaultActivities = defaultActivities.filter(
+      (activity): activity is ActivityDetails => activity !== null && activity !== undefined
+    );
+    console.log('Valid default activities:', validDefaultActivities);
+
+    // Fetch activities dynamically by city
+    const activities = await getActivitiesByCity(location);
+    console.log('Fetched activities by city:', activities);
+
     const filteredActivities = activities.filter((activity: any) => activity && Object.keys(activity).length > 0);
 
-    res.json(filteredActivities);
+    // Remove duplicates by xid
+    const uniqueActivities = filteredActivities.filter(
+      (activity: any) => !validDefaultActivities.some((defaultActivity) => defaultActivity!.xid === activity.xid)
+    );
+
+    // Combine default and unique activities
+    const resultActivities = [...validDefaultActivities, ...uniqueActivities];
+    console.log('Final combined activities:', resultActivities);
+
+    res.json(resultActivities);
   } catch (error) {
     console.error('Error fetching activities:', error);
     res.status(500).send('Error fetching activities');
   }
 });
+
 
 
 

--- a/server/trip.env
+++ b/server/trip.env
@@ -1,5 +1,5 @@
 DB_USER=root
-DB_PASSWORD=341998
+DB_PASSWORD='q1!w2@e3#r4$t5%'
 DB_HOST=localhost
 DB_NAME=trip_nest
 DB_PORT=3306


### PR DESCRIPTION
When you call the route:
http://localhost:3000/api/v1/activities/
You will get 12 default activities from Israel and added to that more activities that you'll get from the API
those are the default trips:
- W219292804 (Hechal Yehuda Synagogue Tel Aviv)
- N681553665 (Suzanne Dallal Dance Center Tel Aviv)
- W43888180 (HaYarkon Park Tel Aviv)
- Q5639048 (Haifa Cinematheque Haifa)
- Q12410485 (Mount Carmel National Park Haifa)
- N2645430237 (Younes and Soraya Nazarian Library, University of Haifa)
- W44285817(Jerusalem Theatre, Jerusalem)
- N1731465814 (Museum for Islamic Art Jerusalem)
- Q2918780 (Ohr ha-Chaim Synagogue Jerusalem)
- Q632602 (Greek Orthodox Church of Jerusalem)
- Q12016578 (Beersheba Theater)
- N1669839900 (Obelisk, Caesarea)